### PR TITLE
Uploaded AVV catalogue can be used directly.

### DIFF
--- a/src/modules/catalogue-management/useCases/uploadAVVCatalogue/index.ts
+++ b/src/modules/catalogue-management/useCases/uploadAVVCatalogue/index.ts
@@ -1,6 +1,4 @@
 import { ObjectKeys } from '../../../shared/infrastructure/parse-types';
 import { beforeAVVCatalogueSaveHook } from './before-avv-catalogue-save.hook';
-import { afterAVVCatalogueSaveHook } from './after-avv-catalogue-save.hook';
 
 Parse.Cloud.beforeSave(ObjectKeys.AVVCatalogue, beforeAVVCatalogueSaveHook);
-Parse.Cloud.afterSave(ObjectKeys.AVVCatalogue, afterAVVCatalogueSaveHook);

--- a/src/modules/orders/infrastructure/repositories/avvcatalogue.repository.ts
+++ b/src/modules/orders/infrastructure/repositories/avvcatalogue.repository.ts
@@ -1,10 +1,12 @@
-import { AVVCatalog } from '../model/avvcatalog.entity';
+import { AbstractRepository } from '../../../shared/infrastructure';
+import { AVVCatalogueObject } from '../../../shared/infrastructure/parse-types';
+import { AVVCatalog } from '../../legacy/model/avvcatalog.entity';
 import {
     AVVCatalogData,
     MibiCatalogData,
     MibiCatalogFacettenData,
     AVVCatalogObject
-} from '../model/legacy.model';
+} from '../../legacy/model/legacy.model';
 
 function createAVVCatalog<T extends AVVCatalogData>(
     data: T,
@@ -13,10 +15,11 @@ function createAVVCatalog<T extends AVVCatalogData>(
     return new AVVCatalog(data, uId);
 }
 
-export class AVVCatalogRepository {
-    private catalogs: {
-        [key: string]: AVVCatalog<AVVCatalogData>;
-    };
+export type AVVCatalogueCacheData = {
+    [key: string]: AVVCatalog<AVVCatalogData>;
+};
+
+export class AVVCatalogueRepository extends AbstractRepository<AVVCatalogueObject> {
     private requiredCatalogNames: string[] = [
         'avv303',
         'avv313',
@@ -27,20 +30,17 @@ export class AVVCatalogRepository {
         'avv326',
         'avv328',
         'avv339'
-        // `zsp${new Date().getFullYear().toString()}`,
-        // `zsp${(new Date().getFullYear() + 1).toString()}`,
-        // `zsp${(new Date().getFullYear() - 1).toString()}`
     ];
 
-    constructor() {
-        this.catalogs = {};
-    }
-
-    async initialise(): Promise<void> {
+    async retrieve(): Promise<AVVCatalogueCacheData> {
         console.log(
-            `${this.constructor.name}.${this.initialise.name}, loading AVV Catalog data from Database.`
+            `${this.constructor.name}.${this.retrieve.name}, loading AVV Catalog data from Database.`
         );
-        const avvCatalogues = await this.retrieve();
+
+        const catalogs: AVVCatalogueCacheData = {};
+
+        const avvCatalogues = await this.retrieveAllCatalogues();
+
         avvCatalogues.forEach(avvCatalogueObject => {
             try {
                 const catalogName = avvCatalogueObject.catalogCode;
@@ -48,38 +48,34 @@ export class AVVCatalogRepository {
                 const data: MibiCatalogData | MibiCatalogFacettenData =
                     catalogData['data'];
                 const uId: string = catalogData['uId'];
-                this.catalogs[`avv${catalogName}`] = createAVVCatalog(
-                    data,
-                    uId
-                );
+
+                const avvCatalogue = createAVVCatalog(data, uId);
+                catalogs[`avv${catalogName}`] = avvCatalogue;
             } catch (error) {
                 console.log(
-                    `Error loading AVV catalog from database: ${error}`
+                    `AVVCatalogueRepository, retrieve(), Error loading AVV catalog data from Database: ${error}`
                 );
             }
         });
+
         this.requiredCatalogNames.forEach(catalogName => {
-            if (
-                !this.catalogs.hasOwnProperty.call(this.catalogs, catalogName)
-            ) {
+            if (!catalogs.hasOwnProperty.call(catalogs, catalogName)) {
                 console.error(
                     `Error: Required AVV Catalog ${catalogName} not found in Database.`
                 );
             }
         });
+
         console.log(
-            `${this.constructor.name}.${this.initialise.name}, finished initialising AVV Catalog Repository from Database.`
+            `${this.constructor.name}.${this.retrieve.name}, finished loading AVV Catalog data from Database.`
         );
+
+        return catalogs;
     }
 
-    getAVVCatalog<T extends AVVCatalogData>(
-        catalogName: string
-    ): AVVCatalog<T> {
-        return this.catalogs[catalogName] as AVVCatalog<T>;
-    }
-
-    private async retrieve(): Promise<AVVCatalogObject[]> {
-        const query = new Parse.Query('AVV_Catalogue');
+    private async retrieveAllCatalogues(): Promise<AVVCatalogObject[]> {
+        const query = this.getQuery();
+        query.ascending('catalogueCode');
         const catalogues: Parse.Object[] = await query.find({
             useMasterKey: true
         });
@@ -93,12 +89,4 @@ export class AVVCatalogRepository {
             catalogData: avvCatalog.get('catalogueData')
         };
     }
-}
-
-let repo: AVVCatalogRepository;
-
-export async function initialiseRepository(): Promise<AVVCatalogRepository> {
-    const repository = repo ? repo : new AVVCatalogRepository();
-    repo = repository;
-    return repository.initialise().then(() => repository);
 }

--- a/src/modules/orders/infrastructure/repositories/index.ts
+++ b/src/modules/orders/infrastructure/repositories/index.ts
@@ -2,10 +2,16 @@ import { ObjectKeys } from '../../../shared/infrastructure/parse-types';
 import { CustomerRepository } from './customer.repository';
 import { PLZRepository } from './plz.repository';
 import { UserRepository } from './user.repository';
+import { AVVCatalogueRepository } from './avvcatalogue.repository';
 
 const plzRepository = new PLZRepository(ObjectKeys.AllowedPLZ);
 const customerRepository = new CustomerRepository(ObjectKeys.UserInformation);
 const userRepository = new UserRepository();
+const avvCatalogueRepository = new AVVCatalogueRepository(
+    ObjectKeys.AVVCatalogue
+);
+
+// console.log('@@@@@@@@ orders/infrastructure/repositories/index new AVVCatalogueRepository(ObjectKeys.AVVCatalogue)')
 
 export {
     CustomerRepository,
@@ -13,5 +19,7 @@ export {
     plzRepository,
     PLZRepository,
     userRepository,
-    UserRepository
+    UserRepository,
+    avvCatalogueRepository,
+    AVVCatalogueRepository
 };

--- a/src/modules/orders/legacy/application/catalog.service.ts
+++ b/src/modules/orders/legacy/application/catalog.service.ts
@@ -8,7 +8,7 @@ import {
     CatalogData,
     SearchAlias
 } from '../model/legacy.model';
-import { AVVCatalogRepository } from '../repositories/avvcatalog.repository';
+import { AVVCatalogueCache } from '../../../shared/infrastructure/cache/avvcatalogue.cache';
 import { CatalogRepository } from '../repositories/catalog.repository';
 import { SearchAliasRepository } from '../repositories/search-alias.repository';
 
@@ -17,7 +17,7 @@ export class CatalogService {
         private plzCache: PLZCache,
         private catalogRepository: CatalogRepository,
         private searchAliasRepository: SearchAliasRepository,
-        private avvCatalogRepository: AVVCatalogRepository
+        private avvCatalogueCache: AVVCatalogueCache
     ) {}
 
     getCatalog<T extends CatalogData>(catalogName: string): Catalog<T> {
@@ -36,7 +36,7 @@ export class CatalogService {
     getAVVCatalog<T extends AVVCatalogData>(
         catalogName: string
     ): AVVCatalog<T> {
-        return this.avvCatalogRepository.getAVVCatalog<T>(catalogName);
+        return this.avvCatalogueCache.getAVVCatalog<T>(catalogName);
     }
 
     getCatalogSearchAliases(catalogName: string) {

--- a/src/modules/orders/legacy/index.ts
+++ b/src/modules/orders/legacy/index.ts
@@ -1,4 +1,8 @@
-import { nrlCache, plzCache } from '../../shared/infrastructure';
+import {
+    nrlCache,
+    plzCache,
+    avvCatalogueCache
+} from '../../shared/infrastructure';
 import { ObjectKeys } from '../infrastructure';
 import {
     ExcelMarshallAntiCorruptionLayer,
@@ -23,7 +27,7 @@ import { SampleSheetService } from './application/sample-sheet.service';
 import { SampleService } from './application/sample.service';
 import { ValidationErrorProvider } from './application/validation-error-provider.service';
 import { pdfConstants, sampleSheetConstants } from './model/legacy.model';
-import { initialiseRepository as avvCatalogRepositoryInit } from './repositories/avvcatalog.repository';
+import { setAVVCatalogueCache } from '../../system-initialise/useCases';
 import { initialiseRepository as catalogRepositoryInit } from './repositories/catalog.repository';
 import { initialiseRepository as searchAliasRepositoryInit } from './repositories/search-alias.repository';
 import { stateRepository } from './repositories/state.repository';
@@ -67,22 +71,13 @@ const antiCorruptionLayers = (async function init() {
         throw error;
     });
 
-    const avvCatalogRepository = await avvCatalogRepositoryInit().catch(
-        (error: Error) => {
-            console.error(
-                `Failed to initialize AVVCatalog Repository. error=${String(
-                    error
-                )}`
-            );
-            throw error;
-        }
-    );
+    await setAVVCatalogueCache.execute();
 
     const catalogService = new CatalogService(
         plzCache,
         catalogRepository,
         searchAliasRepository,
-        avvCatalogRepository
+        avvCatalogueCache
     );
 
     const avvFormatProvider = new AVVFormatProvider(stateRepository);

--- a/src/modules/shared/infrastructure/cache/avvcatalogue.cache.ts
+++ b/src/modules/shared/infrastructure/cache/avvcatalogue.cache.ts
@@ -1,0 +1,26 @@
+import { AVVCatalogueCacheData } from '../../../orders/infrastructure/repositories/avvcatalogue.repository';
+import { AVVCatalog } from '../../../orders/legacy/model/avvcatalog.entity';
+import { AVVCatalogData } from '../../../orders/legacy/model/legacy.model';
+
+class AVVCatalogueCache {
+    private avvCatalogs: AVVCatalogueCacheData;
+
+    setAVVCatalogues(avvCatalogues: AVVCatalogueCacheData) {
+        this.avvCatalogs = avvCatalogues;
+        return this.avvCatalogs;
+    }
+
+    getAVVCatalog<T extends AVVCatalogData>(
+        catalogName: string
+    ): AVVCatalog<T> {
+        return this.avvCatalogs[catalogName] as AVVCatalog<T>;
+    }
+
+    removeAllData() {
+        this.avvCatalogs = {};
+    }
+}
+
+const avvCatalogueCache = new AVVCatalogueCache();
+
+export { avvCatalogueCache, AVVCatalogueCache };

--- a/src/modules/shared/infrastructure/cache/index.ts
+++ b/src/modules/shared/infrastructure/cache/index.ts
@@ -1,2 +1,3 @@
 export { NRLCache, nrlCache } from './nrl.cache';
 export { PLZCache, plzCache } from './plz.cache';
+export { AVVCatalogueCache, avvCatalogueCache } from './avvcatalogue.cache';

--- a/src/modules/system-initialise/index.ts
+++ b/src/modules/system-initialise/index.ts
@@ -7,11 +7,14 @@ import { ObjectKeys } from '../shared/infrastructure/parse-types';
 import {
     afterDeleteNRLHook,
     afterDeletePLZHook,
+    afterDeleteAVVCatalogueHook,
     afterSaveNRLHook,
     afterSavePLZHook,
+    afterSaveAVVCatalogueHook,
     checkSystemConfiguration,
     setNRLCache,
-    setPLZCache
+    setPLZCache,
+    setAVVCatalogueCache
 } from './useCases';
 
 logger.info('Parse Cloud: Checking System Configuration.');
@@ -26,5 +29,10 @@ logger.info('Parse Cloud: Creating PLZ cache.');
 setPLZCache.execute();
 Parse.Cloud.afterSave(ObjectKeys.AllowedPLZ, afterSavePLZHook);
 Parse.Cloud.afterDelete(ObjectKeys.AllowedPLZ, afterDeletePLZHook);
+
+logger.info('Parse Cloud: Creating AVVCatalogue cache.');
+setAVVCatalogueCache.execute();
+Parse.Cloud.afterSave(ObjectKeys.AVVCatalogue, afterSaveAVVCatalogueHook);
+Parse.Cloud.afterDelete(ObjectKeys.AVVCatalogue, afterDeleteAVVCatalogueHook);
 
 logger.info('Parse Cloud: System initialise module loaded.');

--- a/src/modules/system-initialise/useCases/index.ts
+++ b/src/modules/system-initialise/useCases/index.ts
@@ -9,3 +9,8 @@ export {
     afterSavePLZHook,
     setPLZCache
 } from './setPLZCache';
+export {
+    afterDeleteAVVCatalogueHook,
+    afterSaveAVVCatalogueHook,
+    setAVVCatalogueCache
+} from './setAVVCatalogueCache';

--- a/src/modules/system-initialise/useCases/setAVVCatalogueCache/index.ts
+++ b/src/modules/system-initialise/useCases/setAVVCatalogueCache/index.ts
@@ -1,0 +1,8 @@
+export {
+    afterDeleteAVVCatalogueHook,
+    afterSaveAVVCatalogueHook
+} from './set-avvcatalogue-cache.hook';
+export {
+    SetAVVCatalogueCacheUseCase,
+    setAVVCatalogueCache
+} from './set-avvcatalogue-cache.use-case';

--- a/src/modules/system-initialise/useCases/setAVVCatalogueCache/set-avvcatalogue-cache.hook.ts
+++ b/src/modules/system-initialise/useCases/setAVVCatalogueCache/set-avvcatalogue-cache.hook.ts
@@ -1,3 +1,4 @@
+import { setAVVCatalogueCache } from './set-avvcatalogue-cache.use-case';
 import {
     getLogger,
     setLoggingContext
@@ -9,9 +10,14 @@ type AfterAVVCatalogueSaveHookRequest = ParseHookRequest<
     AVVCatalogueObject,
     AVVCatalogueSaveContext
 >;
-export const afterAVVCatalogueSaveHook = async (
+
+export const afterSaveAVVCatalogueHook = async (
     request: AfterAVVCatalogueSaveHookRequest
 ) => {
+    request.log.info(
+        'Changes made to AVV_Catalogue Collection. Updating cache and deleting json file.'
+    );
+
     const avvCatalogueObject: AVVCatalogueObject = request.object;
     const jsonFile = avvCatalogueObject.get('catalogueFile');
     try {
@@ -23,7 +29,19 @@ export const afterAVVCatalogueSaveHook = async (
     } finally {
         setLoggingContext(null);
     }
+
+    setAVVCatalogueCache.execute();
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const afterDeleteAVVCatalogueHook = (request: any) => {
+    request.log.info(
+        'Entry deleted from AVV_Catalogue Collection. Updating cache.'
+    );
+
+    setAVVCatalogueCache.execute();
+};
+
 function destroyFile(file: Parse.File) {
     try {
         file.destroy({ useMasterKey: true });

--- a/src/modules/system-initialise/useCases/setAVVCatalogueCache/set-avvcatalogue-cache.use-case.ts
+++ b/src/modules/system-initialise/useCases/setAVVCatalogueCache/set-avvcatalogue-cache.use-case.ts
@@ -1,0 +1,35 @@
+import { UseCase } from '../../../shared/useCases';
+import {
+    avvCatalogueCache,
+    AVVCatalogueCache
+} from '../../../shared/infrastructure/cache/avvcatalogue.cache';
+import {
+    avvCatalogueRepository,
+    AVVCatalogueRepository
+} from '../../../orders/infrastructure/repositories';
+
+class SetAVVCatalogueCacheUseCase implements UseCase<null, Promise<void>> {
+    constructor(
+        private avvCatalogueCache: AVVCatalogueCache,
+        private avvCatalogueRepository: AVVCatalogueRepository
+    ) {}
+
+    async execute(): Promise<void> {
+        return await this.avvCatalogueRepository
+            .retrieve()
+            .then(data => {
+                this.avvCatalogueCache.removeAllData();
+                this.avvCatalogueCache.setAVVCatalogues(data);
+            })
+            .catch((error: Error) => {
+                throw error;
+            });
+    }
+}
+
+const setAVVCatalogueCache = new SetAVVCatalogueCacheUseCase(
+    avvCatalogueCache,
+    avvCatalogueRepository
+);
+
+export { setAVVCatalogueCache, SetAVVCatalogueCacheUseCase };


### PR DESCRIPTION
Ticket: https://github.com/SiLeBAT/mibi-parse-cloud/issues/22

For the AVV Catalogue Cache the node-cache mechanism is not used because the validation performance with that is to low.
Validating an excel sheet with 15 samples takes 8 - 9 sec.
Instead the simple catalogue object is used as caching object as before, now it is immediately updated after changing the AVV_Catalogue collection in the database.