### PR TITLE
Change popup window Falsche Version des Untersuchungsauftrags verwend

### DIFF
--- a/src/modules/orders/use-cases/check-excel-version/check-excel-version.use-case.ts
+++ b/src/modules/orders/use-cases/check-excel-version/check-excel-version.use-case.ts
@@ -5,6 +5,7 @@ import { UseCase } from '../../../shared/use-cases';
 
 export type ExcelVersionCheck = {
     uploadedExcelVersion: string;
+    currentVersions: string[];
     valid: boolean;
 };
 class CheckExcelVersionUseCase
@@ -26,6 +27,9 @@ class CheckExcelVersionUseCase
 
         return {
             uploadedExcelVersion,
+            currentVersions: Array.isArray(validExcelVersion)
+                ? validExcelVersion
+                : [],
             valid: isValid
         };
     }

--- a/src/modules/orders/use-cases/parse-sample-data/parse-sample-data.controller.ts
+++ b/src/modules/orders/use-cases/parse-sample-data/parse-sample-data.controller.ts
@@ -48,6 +48,7 @@ type ErrorDTO = {
 export interface EmailValidationErrorDTO extends ErrorDTO {}
 export interface ExcelVersionErrorDTO extends ErrorDTO {
     version: string;
+    currentVersions: string[];
 }
 
 /*
@@ -83,6 +84,7 @@ const parseSampleDataController = loggedController(
             if (!matchesExcelVersion.valid) {
                 throw new ExcelVersionError(
                     `Invalid Excel Version:${matchesExcelVersion.uploadedExcelVersion}`,
+                    matchesExcelVersion.currentVersions,
                     new Error(
                         `Invalid Excel Version:${matchesExcelVersion.uploadedExcelVersion}`
                     )
@@ -132,7 +134,8 @@ const parseSampleDataController = loggedController(
                 const dto: ExcelVersionErrorDTO = {
                     code: SERVER_ERROR_CODE.INVALID_VERSION,
                     message: error.message,
-                    version: version
+                    version: version,
+                    currentVersions: error.currentVersions || []
                 };
 
                 return dto;

--- a/src/modules/orders/use-cases/parse-sample-data/parse-sample-data.error.ts
+++ b/src/modules/orders/use-cases/parse-sample-data/parse-sample-data.error.ts
@@ -1,4 +1,10 @@
 import { UseCaseError } from '../../../shared/use-cases';
 
 export class SubmissionCreationFailedError extends UseCaseError {}
-export class ExcelVersionError extends UseCaseError {}
+export class ExcelVersionError extends UseCaseError {
+    currentVersions: string[];
+    constructor(message: string, currentVersions: string[], error: Error) {
+        super(message, error);
+        this.currentVersions = currentVersions;
+    }
+}


### PR DESCRIPTION
Change popup window Falsche Version des Untersuchungsauftrags verwend

Ticket: https://github.com/SiLeBAT/mibi-portal-client/issues/696



...................
Parse Cloud
Problem: The server onlyreturned the uploaded version number in the error response. The client had no way to know the current valid version(s).

check-excel-version.use-case.ts
Added currentVersions: string[] to the return type. Now when the version check runs, it returns not just whether it's valid, but also the list of
currently accepted versions from the Parse config.

parse-sample-data.error.ts
Updated ExcelVersionError to store currentVersions: string[] so it can carry that data through to the controller.

parse-sample-data.controller.ts

Updated ExcelVersionErrorDTO to include currentVersions: string[]
Passes currentVersions when throwing the error
Includes currentVersions in the error response sent back to the client